### PR TITLE
Skip AuthDestroy middleware

### DIFF
--- a/actions/app.go
+++ b/actions/app.go
@@ -65,7 +65,7 @@ func App() *buffalo.App {
 		app.GET("/signin", AuthNew)
 		app.POST("/signin", AuthCreate)
 		app.DELETE("/signout", AuthDestroy)
-		app.Middleware.Skip(Authorize, HomeHandler, UsersNew, UsersCreate, AuthNew, AuthCreate)
+		app.Middleware.Skip(Authorize, HomeHandler, UsersNew, UsersCreate, AuthNew, AuthCreate, AuthDestroy)
 
 		app.Resource("/items", ItemsResource{})
 


### PR DESCRIPTION
Should AuthDestroy middleware be skipped, or am I mistaken?