### PR TITLE
Adding migrate command to README, as it's a required step during setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ You will also need to make sure that **you** start/install the database of your 
 Ok, so you've edited the "database.yml" file and started postgres, now Buffalo can create the databases in that file for you:
 
 	$ buffalo db create -a
+
+### Run Database Migrations
+
+This command will make Buffalo execute the scripts in the "migrations" directory, which will create the necessary tables in the database:
+
+	$ buffalo db migrate
+	
 ## Starting the Application
 
 Buffalo ships with a command that will watch your application and automatically rebuild the Go binary and any assets for you. To do that run the "buffalo dev" command:


### PR DESCRIPTION
Fixes error message: `pq: relation "users" does not exist`