### PR TITLE
fix Dockerfile by removing call 'dep ensure'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ADD package.json .
 ADD yarn.lock .
 RUN yarn install --no-progress
 ADD . .
-RUN dep ensure -v
+
 RUN buffalo build --static -o /bin/app
 
 FROM alpine


### PR DESCRIPTION
Docker image build seems to be broken by 72c97b6dd which deleted `Gopkg.toml`.
This PR fixes it by removing call to `dep ensure` .